### PR TITLE
fix thumbnail url

### DIFF
--- a/plugin.video.easynews/easynewssearchhandler.py
+++ b/plugin.video.easynews/easynewssearchhandler.py
@@ -74,7 +74,7 @@ class EasynewsSearchHandler():
         if len(url) <= 40:
             return None
 
-        firstdot = url.find('.', 40)
+        firstdot = url.find('.', 41)
         if firstdot == -1:
             return None
         nextslash = url.find('/', firstdot)
@@ -85,9 +85,9 @@ class EasynewsSearchHandler():
             return None
 
         thumb_url = 'https://th.easynews.com/thumbnails-'
-        thumb_url += url[40: 43]
+        thumb_url += url[41: 44]
         thumb_url += '/pr-'
-        thumb_url += url[40: firstdot - 4]
+        thumb_url += url[41: firstdot - 4]
         thumb_url += '.jpg/th-'
         thumb_url += url[nextslash + 1: seconddot]
         thumb_url += '.jpg'


### PR DESCRIPTION
Current thumbnail generation logic leads to broken thumbnail urls.

E.g. file link: `https://members.easynews.com/dl/auto/443/2790b226e1cedd7b47924e4587050f9809779f17c77f4.avi/Teen%20Titans%20-%203x11%20-%20%2337%20-%20Bunny%20Raven%20or%20How%20To%20Make%20a%20TitanAnimal%20Disappear.avi`

Output: `https://th.easynews.com/thumbnails-/27/pr-/2790b226e1cedd7b47924e4587050f9809779f17c.jpg/th-Teen%20Titans%20-%203x11%20-%20%2337%20-%20Bunny%20Raven%20or%20How%20To%20Make%20a%20TitanAnimal%20Disappear.jpg`

Expected output: 'https://th.easynews.com/thumbnails-279/pr-2790b226e1cedd7b47924e4587050f9809779f17c.jpg/th-Teen%20Titans%20-%203x11%20-%20%2337%20-%20Bunny%20Raven%20or%20How%20To%20Make%20a%20TitanAnimal%20Disappear.jpg'